### PR TITLE
Add Site.Params to disable search and copyright

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,8 @@
+{{ if .Site.Params.enableCopyright | default true }}
 <footer class="mt-2 pt-2 pb-2">
   <div class="wrap">
     <p>&copy; {{ now.Year}} {{ .Site.Params.author }}</p>
   </div>
 </footer>
+{{ end }}
+

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -9,7 +9,9 @@
 			<img srcset = '{{ $normalPath }}' alt = '{{ .Site.Title }} Logo'>
 		</picture>
 	</a>
+	{{ if .Site.Params.enableSearch | default true }}
 	{{- partial "search.html" . }}
+	{{ end }}
 	<ul class="nav_body">
 		{{- $p := . }}
 		{{- range .Site.Menus.main }}


### PR DESCRIPTION
This PR adds site parameters to optionally disable the search field and the copyright notice. Both, search field and copyright notice, are enabled by default to keep current default behavior.