### PR TITLE
Only print ToC in sidebar if non-empty

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -12,7 +12,9 @@
         {{- range . }}
         {{- if .IsPage }}
         <h3 class="section_link{{ if eq .RelPermalink $permalink }} active{{ end }}"><a id="docs-{{ anchorize .Title }}" href="{{ .Permalink }}">{{ .Title }}</a></h3>
-        {{- .TableOfContents }}
+        {{- if ne (print .TableOfContents) ""}}
+          {{- .TableOfContents }}
+        {{- end }}
         {{- else }}
         {{- template "tree" (dict "page" $page "section" .) }}
         {{- end }}


### PR DESCRIPTION
This PR enhances the sidebar such that it only attempts to print the table of contents (ToC), if it's non-empty. Otherwise, if you have a doc file with empty toc, it will show an artifact for the actively selected doc file.