### PR TITLE
Use render hooks for links and lazyloading

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -368,15 +368,6 @@ function loadActions() {
       });
     }
   })();
-
-  (function lazyLoadImages() {
-    const images = elems('img');
-    images.forEach(function(image){
-      // supported natively by most modern browsers. 
-      image.loading = "lazy";
-    });
- })();
-
 }
 
 window.addEventListener('load', loadActions());

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -257,30 +257,6 @@ function loadActions() {
     
   })();
 
-  (function markExternalLinks(){
-    let links = elems('a');
-    const contentWrapperClass = '.content';
-    if(links) {
-      Array.from(links).forEach(function(link, index){
-        let target, rel, blank, noopener, attr1, attr2, url, isExternal;
-        url = elemAttribute(link, 'href');
-        isExternal = (url && typeof url == 'string' && url.startsWith('http')) && !url.startsWith(parentURL) && link.closest(contentWrapperClass);
-        index === 1 ? console.log(parentURL) : false;
-        if(isExternal) {
-          target = 'target';
-          rel = 'rel';
-          blank = '_blank';
-          noopener = 'noopener';
-          attr1 = elemAttribute(link, target);
-          attr2 = elemAttribute(link, noopener);
-
-          attr1 ? false : elemAttribute(link, target, blank);
-          attr2 ? false : elemAttribute(link, rel, noopener);
-        }
-      });
-    }
-  })();
-
   let headingNodes = [], results, link, icon, current, id,
   tags = ['h2', 'h3', 'h4', 'h5', 'h6'];
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,1 @@
+<img loading="lazy" src="{{ .Destination | safeURL }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}"{{ end }} />

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
Removed JavaScript lazyload tag and switched to Hugo's native Render Hooks! 

See docs: https://gohugo.io/getting-started/configuration-markup/#markdown-render-hooks