### PR TITLE
Fix some URL operations which don't work when the base url has no "/" at the end

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -91,10 +91,9 @@ function isMatch(element, selectors) {
 }
 
 function closestInt(goal, collection) {
-  const closest = collection.reduce(function(prev, curr) {
+  return collection.reduce(function (prev, curr) {
     return (Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev);
   });
-  return closest;
 }
 
 function hasClasses(el) {
@@ -147,14 +146,12 @@ function wrapText(text, context, wrapper = 'mark') {
   const hyperLinks = elems('a');
   if(hyperLinks) {
     hyperLinks.forEach(function(link){
-      const href = link.href.replaceAll(encodeURI(open), "").replaceAll(encodeURI(close), "");
-      link.href = href;
+      link.href = link.href.replaceAll(encodeURI(open), "").replaceAll(encodeURI(close), "");
     });
   }
 }
 
 function parseBoolean(string) {
-  let bool;
   string = string.trim().toLowerCase();
   switch (string) {
     case 'true':
@@ -164,10 +161,10 @@ function parseBoolean(string) {
     default:
       return undefined;
   }
-};
+}
 
 function loadSvg(file, parent, path = 'icons/') {
-  const link = `${parentURL}${path}${file}.svg`;
+  const link = new URL(`${path}${file}.svg`, rootURL).href;
   fetch(link)
   .then((response) => {
     return response.text();

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -132,7 +132,7 @@ function loadActions() {
       Array.from(links).forEach(function(link, index){
         let target, rel, blank, noopener, attr1, attr2, url, isExternal;
         url = elemAttribute(link, 'href');
-        isExternal = (url && typeof url == 'string' && url.startsWith('http')) && !url.startsWith(parentURL) && link.closest(contentWrapperClass);
+        isExternal = (url && typeof url == 'string' && url.startsWith('http')) && !url.startsWith(rootURL) && link.closest(contentWrapperClass);
         if(isExternal) {
           target = 'target';
           rel = 'rel';

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -124,7 +124,7 @@ function liveSearch() {
       searchField.addEventListener('search', function(){
         const searchTerm = searchField.value.trim().toLowerCase();
         if(searchTerm.length)  {
-          window.location.href = `${parentURL}search/?query=${searchTerm}`;
+          window.location.href = new URL(`search/?query=${searchTerm}`, rootURL).href;
         }
       });
     }

--- a/assets/js/variables.js
+++ b/assets/js/variables.js
@@ -5,7 +5,7 @@ const showId = 'show';
 const menu = 'menu';
 
 // defined in config.toml
-const parentURL = '{{ absURL "" }}';
+const rootURL = '{{ absURL "" }}';
 
 // defined in i18n / translation files
 const quickLinks = '{{ T "quick_links" }}';


### PR DESCRIPTION
Some URL operations didn't work correctly when the root URL doesn't  have a slash at the end. The new variant uses the JavaScript URL constructor. I tested it on my custom domain and it worked correctly. Of course it's still working on localhost too.