### PR TITLE
Google Lighthouse optimisations and document theme variable override

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -91,10 +91,9 @@ function isMatch(element, selectors) {
 }
 
 function closestInt(goal, collection) {
-  const closest = collection.reduce(function(prev, curr) {
+  return collection.reduce(function (prev, curr) {
     return (Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev);
   });
-  return closest;
 }
 
 function hasClasses(el) {
@@ -147,14 +146,12 @@ function wrapText(text, context, wrapper = 'mark') {
   const hyperLinks = elems('a');
   if(hyperLinks) {
     hyperLinks.forEach(function(link){
-      const href = link.href.replaceAll(encodeURI(open), "").replaceAll(encodeURI(close), "");
-      link.href = href;
+      link.href = link.href.replaceAll(encodeURI(open), "").replaceAll(encodeURI(close), "");
     });
   }
 }
 
 function parseBoolean(string) {
-  let bool;
   string = string.trim().toLowerCase();
   switch (string) {
     case 'true':
@@ -164,10 +161,10 @@ function parseBoolean(string) {
     default:
       return undefined;
   }
-};
+}
 
 function loadSvg(file, parent, path = 'icons/') {
-  const link = `${parentURL}${path}${file}.svg`;
+  const link = new URL(`${path}${file}.svg`, rootURL).href;
   fetch(link)
   .then((response) => {
     return response.text();

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -131,8 +131,9 @@ function loadActions() {
     if(links) {
       Array.from(links).forEach(function(link, index){
         let target, rel, blank, noopener, attr1, attr2, url, isExternal;
-        url = elemAttribute(link, 'href');
-        isExternal = (url && typeof url == 'string' && url.startsWith('http')) && !url.startsWith(rootURL) && link.closest(contentWrapperClass);
+        url = new URL(elemAttribute(link, 'href'));
+        // definition of same origin: RFC 6454, section 4 (https://tools.ietf.org/html/rfc6454#section-4)
+        isExternal = url.host !== location.host || url.protocol !== location.protocol || url.port !== location.port;
         if(isExternal) {
           target = 'target';
           rel = 'rel';

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -131,7 +131,7 @@ function loadActions() {
     if(links) {
       Array.from(links).forEach(function(link, index){
         let target, rel, blank, noopener, attr1, attr2, url, isExternal;
-        url = new URL(elemAttribute(link, 'href'));
+        url = new URL(link.href);
         // definition of same origin: RFC 6454, section 4 (https://tools.ietf.org/html/rfc6454#section-4)
         isExternal = url.host !== location.host || url.protocol !== location.protocol || url.port !== location.port;
         if(isExternal) {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -132,7 +132,7 @@ function loadActions() {
       Array.from(links).forEach(function(link, index){
         let target, rel, blank, noopener, attr1, attr2, url, isExternal;
         url = elemAttribute(link, 'href');
-        isExternal = (url && typeof url == 'string' && url.startsWith('http')) && !url.startsWith(parentURL) && link.closest(contentWrapperClass);
+        isExternal = (url && typeof url == 'string' && url.startsWith('http')) && !url.startsWith(rootURL) && link.closest(contentWrapperClass);
         if(isExternal) {
           target = 'target';
           rel = 'rel';

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -124,7 +124,7 @@ function liveSearch() {
       searchField.addEventListener('search', function(){
         const searchTerm = searchField.value.trim().toLowerCase();
         if(searchTerm.length)  {
-          window.location.href = `${parentURL}search/?query=${searchTerm}`;
+          window.location.href = new URL(`search/?query=${searchTerm}`, rootURL).href;
         }
       });
     }

--- a/assets/js/variables.js
+++ b/assets/js/variables.js
@@ -5,7 +5,7 @@ const showId = 'show';
 const menu = 'menu';
 
 // defined in config.toml
-const parentURL = '{{ absURL "" }}';
+const rootURL = '{{ absURL "" }}';
 
 // defined in i18n / translation files
 const quickLinks = '{{ T "quick_links" }}';

--- a/assets/sass/_fonts.sass
+++ b/assets/sass/_fonts.sass
@@ -4,33 +4,39 @@ $font-path: "../fonts"
   font-style: normal
   font-weight: 400
   src: local('Metropolis Regular'), local('Metropolis-Regular'), url('#{$font-path}/Metropolis-Regular.woff2') format('woff2'), url('#{$font-path}/Metropolis-Regular.woff') format('woff')
+  font-display: swap
 
 @font-face
   font-family: 'Metropolis'
   font-style: normal
   font-weight: 300
   src: local('Metropolis Light'), local('Metropolis-Light'), url('#{$font-path}/Metropolis-Light.woff2') format('woff2'), url('#{$font-path}/Metropolis-Light.woff') format('woff')
+  font-display: swap
 
 @font-face
   font-family: 'Metropolis'
   font-style: italic
   font-weight: 300
   src: local('Metropolis Light Italic'), local('Metropolis-LightItalic'), url('#{$font-path}/Metropolis-LightItalic.woff2') format('woff2'), url('#{$font-path}/Metropolis-LightItalic.woff') format('woff')
+  font-display: swap
 
 @font-face
   font-family: 'Metropolis'
   font-style: normal
   font-weight: 500
   src: local('Metropolis Medium'), local('Metropolis-Medium'), url('#{$font-path}/Metropolis-Medium.woff2') format('woff2'), url('#{$font-path}/Metropolis-Medium.woff') format('woff')
+  font-display: swap
 
 @font-face
   font-family: 'Metropolis'
   font-style: italic
   font-weight: 500
   src: local('Metropolis Medium Italic'), local('Metropolis-MediumItalic'), url('#{$font-path}/Metropolis-MediumItalic.woff2') format('woff2'), url('#{$font-path}/Metropolis-MediumItalic.woff') format('woff')
+  font-display: swap
 
 @font-face
   font-family: 'Cookie'
   font-style: normal
   font-weight: 400
   src: local('Cookie-Regular'), url('#{$font-path}/cookie-v10-latin-regular.woff2') format('woff2'), url('#{$font-path}/cookie-v10-latin-regular.woff') format('woff')
+  font-display: swap

--- a/exampleSite/content/docs/compose/customize.md
+++ b/exampleSite/content/docs/compose/customize.md
@@ -39,3 +39,14 @@ These modifiers are classes you can use with shortcodes to customize the look an
 Under `params` add `enableDarkMode = false` to your `config.toml` file. If your site is based on the exampleSite, the value is already included; you only need to uncomment it.
 
 > The user will still have the option to activate dark mode, if they so wish through the UI
+
+### How do I change the theme color?
+If the theme is a git submodule, you can copy the file `assets/sass/_variables.sass` from the theme into your own site.  
+The location must be exactly the same as in the theme, so put it in `YourFancySite/assets/sass/`.
+You can then edit the file to customize the theme color in your site without having to modify the theme itself.
+
+### How can I change the address bar color on mobile devices?
+Just put the following line in the `[params]` section in your `config.toml` file (and of course change the color):
+````toml
+metaThemeColor = "#123456"
+````

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -32,5 +32,5 @@
 {{ else if .IsPage }}
   <meta name="description" content="{{ .Summary | plainify }}">
 {{ else if .Site.Params.Description }}
-  <meta name="descripion" content="{{.}}">
+  <meta name="descripion" content="{{.Site.Params.Description }}">
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,3 +21,16 @@
 {{- $options := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" "true") -}}
 {{- $styles := resources.Get "sass/main.sass" | resources.ExecuteAsTemplate "main.sass" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
 <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
+
+{{- $sp := .Site.Params }}
+{{ with $sp.metaThemeColor }}
+  <meta name="theme-color" content="{{.}}">
+{{ end }}
+
+{{ if .Description }}
+  <meta name="description" content="{{ .Description }}">
+{{ else if .IsPage }}
+  <meta name="description" content="{{ .Summary | plainify }}">
+{{ else if .Site.Params.Description }}
+  <meta name="descripion" content="{{.}}">
+{{ end }}


### PR DESCRIPTION
I let Google Lighthouse analyze my page which uses this theme and it reported some smaller warnings/errors.
I managed to fix all theme-related errors.

I also documented how the user can override the theme color (from #31)

And I added the possibility to customize the [meta theme-color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)