### PR TITLE
Fix customizeSidebar() error on non-english ids

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -105,7 +105,7 @@ function loadActions() {
         });
 
         const linkPositions = pageIds.map(function(id){
-          const heading = document.getElementById(id.replace('#',''));
+          const heading = document.getElementById(decodeURIComponent(id.replace('#','')));
           const position = heading.offsetTop;
           return position;
         });


### PR DESCRIPTION
Hello,

## Changes / fixes

- this PR fixes broken sidebar autoscoll/scroll spy for non-english headings.

## Explanation

If you add heading like `Привет мир` (russian), hugo will generate anchor `#привет-мир`, example:

```markdown
# Привет мир
```
will be:

```html
<h1 id="#привет-мир">Привет мир</h1>
```

but in js code, `id` will be url encoded: `#%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82-%D0%BC%D0%B8%D1%80`, so when js tries to `document.getElementById` null is returned which breaks scroll spy and color mode/theme (including slider, yep)

## Checklist

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
