### PR TITLE
fix small bug in search.js

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -195,7 +195,7 @@ function initializeSearch(index) {
 }
 
 window.addEventListener('load', function() { 
-  fetch(`${rootURL}index.json`)
+  fetch(new URL("index.json", rootURL).href)
   .then(response => response.json())
   .then(function(data) {
     data = data.length ? data : [];


### PR DESCRIPTION
Just a very small bugfix so the search works when the root URL is something like `https://www.example.com` by using the JavaScript `URL` class instead of a simple string concatenation.