### PR TITLE
Set rootURL to the site's baseURL

### DIFF
--- a/assets/js/variables.js
+++ b/assets/js/variables.js
@@ -4,7 +4,8 @@ const toggleId = 'toggle';
 const showId = 'show';
 const menu = 'menu';
 const active = 'active';
-const rootURL = window.location.protocol + "//" + window.location.host;
+// rootURL must end with '/' for relative URLs to work properly
+const rootURL = '{{ strings.TrimSuffix "/" .Site.BaseURL }}/';
 const searchFieldClass = '.search_field';
 const searchClass = '.search';
 


### PR DESCRIPTION
This fixes loading images and other assets in javascripts, when the site
is not deployed to the root folder, but into a sub-folder.

The fix replaces the server host based `rootURL` with Hugo's `baseURL`.
Since this URL is used in calls to `new URL`, it needs to end with a
trailing slash for the URLs to be constructed correctly.

Fixes https://github.com/onweru/compose/issues/74

