### PR TITLE
Add option to remove filter on table charts

### DIFF
--- a/exampleSite/content/docs/compose/graphs-charts-tables.md
+++ b/exampleSite/content/docs/compose/graphs-charts-tables.md
@@ -90,8 +90,14 @@ Firstly define the data you want to display from the front matter:
   {{< chart "dataset2" "pie,doughnut" "1" >}}
 {{< /grid >}}
 
-#### Show table only
+#### Show table with filter
 
 {{< grid "3" >}}
   {{< chart "dataset2" "table" >}}
+{{< /grid >}}
+
+#### Show table only
+
+{{< grid "3" >}}
+  {{< chart "dataset2" "table,noFilter" >}}
 {{< /grid >}}

--- a/layouts/shortcodes/chart.html
+++ b/layouts/shortcodes/chart.html
@@ -27,9 +27,11 @@
 {{- if in $charts "table" }}
 <script src = '{{ absURL "js/w3.js" }}'></script>
 <div class="table_wrap">
+  {{- if not (in $charts "noFilter") }}
   <p>
     <input oninput="w3.filterHTML('#chartTable', '.row', this.value)" class="form_search search_field" placeholder="Filter Table Values">
   </p>
+  {{- end }}
   <table id="chartTable">
     <thead>
       {{- range $index, $title := $data.columnTitles }}


### PR DESCRIPTION
This PR...

## Changes / fixes

- Added optional parameter to specify removal of filter on a table chart
- Parameter is negated so the change is passive; could also be non-passive if negation is not preferred

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/17950836/158137886-af7a163b-6bdf-4b4b-b811-90f582c47e4f.png)

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [X] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies (N/A)
- [x] updated the [docs]() ⚠️
