### PR TITLE
Fix forEach error on empty variable

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -109,7 +109,7 @@ function loadActions() {
           tocItems.forEach(function(item){
             pushClass(item, 'toc_item');
             pushClass(item.firstElementChild, 'toc_link');
-          })
+          });
         }
       });
 
@@ -143,12 +143,14 @@ function loadActions() {
     }
 
     const paragraphs = elems('p');
-    paragraphs.forEach(function(p){
-      const buttons = elems('.button', p);
-      if(buttons.length > 1) {
-        pushClass(p, 'button_grid');
-      }
-    });
+    if (paragraphs) {
+      paragraphs.forEach(function(p){
+        const buttons = elems('.button', p);
+        if(buttons.length > 1) {
+          pushClass(p, 'button_grid');
+        }
+      });
+    }
   })();
 
   (function markExternalLinks(){
@@ -216,7 +218,7 @@ function loadActions() {
     copyText.innerText = 'Link Copied';
     if(!elem(`.${yanked}`, parent)) {
       parent.appendChild(copyText);
-      setTimeout(function() { 
+      setTimeout(function() {
         parent.removeChild(copyText)
       }, 2250);
     }
@@ -378,7 +380,7 @@ function loadActions() {
       } else {
         deleteClass(toTop, active);
       }
-    })
+    });
   })();
 
 }


### PR DESCRIPTION
This PR...

## Changes / fixes

- Added empty variable check before `forEach` call

## Screenshots (if applicable)

N/A

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies (N/A)
- [x] updated the [docs]() ⚠️ (N/A)

## Notes

While using this as a theme I encountered an error with this variable being empty.

<img width="577" alt="image" src="https://user-images.githubusercontent.com/17950836/161459949-4e6a9dee-076b-49e6-bfbc-0256d82dd054.png">

After investigation I found the reason why this hasn't been a problem on the example site. The [default footer](https://github.com/onweru/compose/blob/master/layouts/partials/footer.html#L5) contains a `<p>` tag which makes this variable non-empty even if the page being loaded doesn't have any paragraphs. While using this theme I had added a custom footer and the page erring didn't have any paragraphs, which caused the variable to be empty.

Checking for emptiness before calling `forEach` on a variable is done other places in the codebase [[1](https://github.com/onweru/compose/blob/master/assets/js/code.js#L161-L162)][[2](https://github.com/onweru/compose/blob/master/assets/js/code.js#L180-L181)][[3](https://github.com/onweru/compose/blob/master/assets/js/functions.js#L121-L122)][[4](https://github.com/onweru/compose/blob/master/assets/js/functions.js#L129-L130)] and is generally a good practice to avoid errors like this. It may be worth adding a check before every instance of `forEach` unless there is certainty that the variable will be non-empty.