### PR TITLE
Dynamic localization for menus and logo click

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,7 +1,7 @@
 {{- $s := .Site }}
 {{- $sp := $s.Params }}
 <nav class="wrap nav menu">
-	<a href="{{ $s.BaseURL }}" class="nav_brand">
+	<a href='{{ relLangURL "" }}' class="nav_brand">
 		{{- $logos := $sp.logo }}
 		{{- $litPath := absURL ($logos.lightMode) }}
 		{{- $darkPath := absURL ($logos.darkMode) }}
@@ -23,11 +23,11 @@
 			{{- with .Page }}
 			{{- $active = or $active ( $.IsDescendant .)  }}
 			{{- end }}
-			{{- $url := absURL .URL }}
+			{{- $url := relLangURL .URL }}
 			{{- if or (hasPrefix .URL "http") (hasPrefix .URL "www.") }}
 				{{- $url = .URL }}
 			{{- end }}
-			<a class="nav-link{{if $active }} active{{end}}" href="{{ $url }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
+			<a class="nav-link{{if $active }} active{{end}}" href="{{ $url }}"><span{{if $active }} class="active"{{end}}>{{ T .Identifier | default .Name }}</span></a>
 		</li>
 		{{- end }}
 		{{ $repo := $sp.source }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,7 +1,7 @@
 {{- $s := .Site }}
 {{- $sp := $s.Params }}
 <nav class="wrap nav menu">
-	<a href='{{ relLangURL "" }}' class="nav_brand">
+	<a href='{{ absLangURL "" }}' class="nav_brand">
 		{{- $logos := $sp.logo }}
 		{{- $litPath := absURL ($logos.lightMode) }}
 		{{- $darkPath := absURL ($logos.darkMode) }}
@@ -23,7 +23,7 @@
 			{{- with .Page }}
 			{{- $active = or $active ( $.IsDescendant .)  }}
 			{{- end }}
-			{{- $url := relLangURL .URL }}
+			{{- $url := absLangURL .URL }}
 			{{- if or (hasPrefix .URL "http") (hasPrefix .URL "www.") }}
 				{{- $url = .URL }}
 			{{- end }}


### PR DESCRIPTION
## Changes / fixes

- Instead of using `config/_default/menus/*.toml`, this allows the use of a single `menu.toml` with `identifier = '...'` and translations in `i18n/*.toml`, as specified in https://gohugo.io/content-management/multilingual/#dynamically-localizing-menus-with-i18n
- Clicking the logo will go to the landing page while remaining in the chosen translation

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies
- [ ] updated the [docs]() ⚠️
