### PR TITLE
Add dynamic localization to author URL in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 <footer class="pt-2 pb-2">
   <div class="wrap">
     {{- $author := site.Params.author }}
-    <p>&copy; <span class="year">{{ now.Year }}</span>{{ with $author }} <a href ="{{ .url }}" target="_blank" rel="noopener">{{ .name }}</a>{{ end }}</p>
+    <p>&copy; <span class="year">{{ now.Year }}</span>{{ with $author }} <a href ="{{ absLangURL .url }}" target="_blank" rel="noopener">{{ .name }}</a>{{ end }}</p>
     <a href="#pagetop" id="toTop" title={{ T "to_top" }}></a>
   </div>
 </footer>


### PR DESCRIPTION
## Changes

Say the author URL is `about/legal`, then `absLangURL` makes sure
1. it will go to the right page of the current language
2. it will not be a relative link (which breaks when in other sections)

External URL (starting with `http(s)://` will still work.

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [x] added new dependencies
- [ ] updated the [docs]() ⚠️
