### PR TITLE
Don't show empty <li> and <a> when no repo provided

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -30,6 +30,7 @@
 			<a class="nav-link{{if $active }} active{{end}}" href="{{ $url }}"><span{{if $active }} class="active"{{end}}>{{ T .Identifier | default .Name }}</span></a>
 		</li>
 		{{- end }}
+		{{ if $sp.source }}
 		{{ $repo := $sp.source }}
 		<li class="nav-item nav_repo">
 			<a class="nav-link" href="{{ $repo.url }}" target="_blank">
@@ -44,6 +45,7 @@
 				{{ end }}
 			</a>
 		</li>
+		{{ end }}
 		<li class="nav-item">{{ partial "mode" . }}</li>
 	</ul>
 </nav>


### PR DESCRIPTION
This PR avoids showing empty `<li>` and `<a>` elements when no repository is provided via the config file `params.toml`.

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
