### PR TITLE
Hardspace was being rendered as escaped HTML

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
       &copy; <span class="year">{{ now.Year }}</span>
       {{- if $config.enableCopyright  }}
         {{ with $author }}
-        &nsbp;<a href="{{ absLangURL .url }}" target="_blank" rel="noopener">{{ .name }}</a>
+        <a href="{{ absLangURL .url }}" target="_blank" rel="noopener">{{ .name }}</a>
         {{ end }}
       {{ end }}
     </p>


### PR DESCRIPTION
`&nbsp;` was rendered as escaped HTML and is not actually needed

## Checklist

_Ensure you have checked off the following before submitting your PR._

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [ ] added new dependencies
- [ ] updated the [docs]() ⚠️
