### PR TITLE
i18n: add German translation

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,32 @@
+[copy]
+  other = "Kopieren"
+[copied]
+  other = "Kopiert"
+[docs_menu]
+  other = "Dokumentationsmenü"
+[no_matches]
+  other = "Keine Übereinstimmung gefunden"
+[not_set]
+  other = "undefiniert"
+[resize_snippet]
+  other = "Höhe des Snippets ändern"
+[quick_links]
+  other = "Schnellzugriff"
+[search_field_placeholder]
+  other = "Suche"
+[search_results_label]
+  other = "Suchergebnisse"
+[short_search_query]
+  other = "Anfrage ist zu kurz"
+[site]
+  other = "Webseite"
+[site_menu]
+  other = "Menü der Webseite"
+[toggle_line_numbers]
+  other = "Zeilennummern ein- oder ausblenden"
+[toggle_line_wrap]
+  other = "Zeilenumbruch aktivieren oder deaktivieren"
+[to_top]
+  other = "Zurück zum Anfang"
+[type_to_search]
+  other = "Suchbegriff eingeben"


### PR DESCRIPTION
This PR contributes the German translation to the theme.

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)