### PR TITLE
Make dark mode toggle more vertically aligned with nav

### DIFF
--- a/assets/sass/_components.sass
+++ b/assets/sass/_components.sass
@@ -240,8 +240,7 @@
 
 .color
   &_mode
-    height: 1rem
-    margin-left: 1.5rem
+    margin-left: 1rem
 
   &_choice
     outline: none
@@ -262,15 +261,11 @@
       bottom: 0
       left: 0
       position: absolute
-      height: 0.8rem
+      height: 1.3rem
       background: var(--accent)
-      width: 0.8rem
-      border-radius: 0.25rem
+      width: 1.3rem
+      border-radius: 0.4rem
       z-index: 3
-      transform: scale(1.67)
-      transform-origin: 50% 50%
-      transition: transform 0.5s cubic-bezier(.19,1,.22,1)
-      will-change: transform
       background-image: var(--sun-icon)
       background-size: 60%
       background-repeat: no-repeat


### PR DESCRIPTION
## Screenshots

Before:
![before](https://github.com/onweru/compose/assets/9170316/123c96f5-b920-43ea-9e9b-de239ca893cf)

After:
![after](https://github.com/onweru/compose/assets/9170316/f2ef272e-5770-42c1-a637-f1595055a1af)

## Checklist

- [x] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)