### PR TITLE
PageSize and resource.ToCSS deprecations

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -3,7 +3,7 @@
 {{- .Data.Terms }}
 <div class="wrap pt-2 mt-2">
   {{- $paginator := .Paginate $pages -}}
-  {{- $size := $paginator.PageSize }}
+  {{- $size := $paginator.PagerSize }}
   {{- $scratch := newScratch }}
   {{- range $index, $value := $paginator.Pages }}
     {{- if isset .Params "image" }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -2,7 +2,7 @@
 {{- $pages := where site.RegularPages "Section" site.Params.blogDir  }}
 <div class="wrap pt-2 mt-2">
   {{- $paginator := .Paginate $pages -}}
-  {{- $size := $paginator.PageSize }}
+  {{- $size := $paginator.PagerSize }}
   {{- $scratch := newScratch }}
   {{- range $index, $value := $paginator.Pages }}
     {{- if isset .Params "image" }}

--- a/layouts/partials/head/index.html
+++ b/layouts/partials/head/index.html
@@ -19,7 +19,7 @@
 {{- partial "opengraph" . -}}
 
 {{- $options := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" "true") -}}
-{{- $styles := resources.Get "sass/main.sass" | resources.ExecuteAsTemplate "main.sass" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
+{{- $styles := resources.Get "sass/main.sass" | resources.ExecuteAsTemplate "main.sass" . | css.Sass $options | resources.Fingerprint "sha512" }}
 <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
 
 {{- $config := site.Params }}


### PR DESCRIPTION
This PR addresses the two deprecations within Hugo now being warned about in Hugo v134.2

## Changes / fixes

: PageSize becomes PagerSize
: resource.ToCSS becomes css.Sass