### PR TITLE
Fix incorrect cached link positions on firefox

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -52,7 +52,7 @@ function featureHeading(){
   }
 }
 
-function activeHeading(position, list_links) {
+function activeHeading(index, list_links) {
   let links_to_modify = Object.create(null);
   links_to_modify.active = list_links.filter(function(link) {
     return containsClass(link, active);
@@ -60,9 +60,7 @@ function activeHeading(position, list_links) {
 
   // activeTocLink ? deleteClass
 
-  links_to_modify.new = list_links.filter(function(link){
-    return parseInt(link.dataset.position) === position
-  })[0];
+  links_to_modify.new = list_links[index]
 
   if (links_to_modify.active != links_to_modify.new) {
     links_to_modify.active ? deleteClass(links_to_modify.active, active): false;
@@ -107,26 +105,19 @@ function customizeSidebar() {
     if(current_toc) {
       const page_internal_links = Array.from(elems('a', current_toc));
 
-      const page_ids = page_internal_links.map(function(link){
-        return link.hash;
-      });
-
-      const link_positions = page_ids.map(function(id){
-        const heading = document.getElementById(decodeURIComponent(id.replace('#','')));
-        const position = heading.offsetTop;
-        return position;
-      });
-
-      page_internal_links.forEach(function(link, index){
-        link.dataset.position = link_positions[index]
+      const page_links = page_internal_links.map(function(link){
+        return document.getElementById(decodeURIComponent(link.hash.replace('#','')));
       });
 
       window.addEventListener('scroll', function(e) {
-        // this.setTimeout(function(){
-        let position = window.scrollY;
-        let active = closestInt(position, link_positions);
-        activeHeading(active, page_internal_links);
-        // }, 1500)
+        let position = window.scrollY + window.innerHeight/2;
+        let active_index = 0;
+        for (const [index, element] of page_links.entries()) {
+          if(element.offsetTop < position && element.offsetTop > page_links[active_index].offsetTop) {
+            active_index = index;
+          }
+        }
+        activeHeading(active_index, page_internal_links);
       });
     }
   }


### PR DESCRIPTION
This PR fixes an issue where the wrong positions would be recorded to TOC elements under firefox:

- I suspect that the window 'load' event listener is fired too early, before images are loaded. This results in recorded positions being significantly smaller than their final positions after loading completes.
- Manually calling `loadActions()` through a debugging console fixes the issue.
- This isn't an issue under chromium.

## Changes / fixes

- Rather than record page link offsets to a `position` in html elements, save references in js for lookup within the event listener callback.
- Switched from a `closestInt` comparison to closest without going over.
  - The previous method led to strange behavior with long sections where the TOC would switch active headings before the new heading is even on the screen.
  - The current behavior is to highlight the next section once it's half way up the screen.
  - Different behavior (e.g., switch active sections when page link is at top of screen) could be attained by modifying line 113.

## Screenshots

### Before:
![Before](https://github.com/user-attachments/assets/3d39d5c7-5623-4a13-9f15-3e75d01bb937)

### After:
![After](https://github.com/user-attachments/assets/7c4ca406-563f-4c1f-b300-2814fd2ebef3)

## Checklist

- [X] tested locally with the [latest release of Hugo](https://github.com/gohugoio/hugo/releases). This requirement is [a standard](https://github.com/gohugoio/hugoThemes#theme-maintenance)
- [NA] added new dependencies
- [NA] updated the [docs]() ⚠️
